### PR TITLE
Update gitrepositories.md (fixes #201)

### DIFF
--- a/pages/vi/gitrepositories.md
+++ b/pages/vi/gitrepositories.md
@@ -19,8 +19,8 @@ This is just a summary of the steps that you will need to perform. Keep on readi
 
 
 * [Clone Your GitHub Repository username.github.io](#Clone_Your_GitHub_Repository_username.github.io)
-* [Clone with HTTPS or Clone with SSH?](#Clone_with_HTTPS_or_Clone_with_SSH?)
-* [Explanation About Repositories and Syncing Process](#Explanation_About_Repositories_and_Syncing_Process)
+* [Clone with HTTPS or Clone with SSH?](#Clone_with_HTTPS_or_SSH)
+* [Explanation About Repositories and Syncing Process](#Repositories_and_the_Syncing_Process)
 * [Configure a Remote Repository for Your Fork](#Configure_a_Remote_Repository_for_Your_Fork)
 * [Sync Your Fork](#Sync_Your_Fork)
 


### PR DESCRIPTION
Change the hyperlink of ***"Clone with HTTPS or Clone with SSH?"*** and ***"Explanation About Repositories and Syncing Process"*** of ***Start here***. Now it can jump to the right place.