### PR TITLE
Add Former Interns page and User Not Found page (Fixes #200, #227)

### DIFF
--- a/pages/vi/profilenotfound.md
+++ b/pages/vi/profilenotfound.md
@@ -1,0 +1,4 @@
+### Profile Not Found
+
+Sorry, this user has not provided a profile!
+[Go Back to Members Page](team.md)

--- a/pages/vi/profilenotfound.md
+++ b/pages/vi/profilenotfound.md
@@ -1,4 +1,5 @@
 ### Profile Not Found
 
 Sorry, this user has not provided a profile!
+
 [Go Back to Members Page](team.md)

--- a/pages/vi/profilenotfound.md
+++ b/pages/vi/profilenotfound.md
@@ -1,5 +1,0 @@
-### Profile Not Found
-
-Sorry, this user has not provided a profile!
-
-[Go Back to Members Page](team.md)

--- a/pages/vi/profiles/Kid243.md
+++ b/pages/vi/profiles/Kid243.md
@@ -1,0 +1,6 @@
+# Shalom brethren
+My name is __Dijimba Kabuyi Ilunga__ . I go by _Joss_ most of the time. I reside currently in Arlington, Texas (central standard time). My operating system is Windows 10.
+
+![lpok](https://c2.staticflickr.com/8/7252/7452386316_928c2b552d_b.jpg)
+
+I possess a Bachelor of Science degree in Electrical Engineering (University of Texas at Arlington) and a Robotics Specialization certification (University of Pennsylvania).

--- a/pages/vi/profiles/Liew211.md
+++ b/pages/vi/profiles/Liew211.md
@@ -1,0 +1,18 @@
+# Sam Liew
+
+| Location | Time Zone | OS |
+| :--- | --- | :--- |
+| Fishkill, NY | EDT | macOS High Sierra 10.13.4 |
+
+## About Me
+
+Hi, I am currently an undergraduate engineering student at the [University of Waterloo](https://www.uwaterloo.ca).
+
+![Alt Text](https://www.570news.com/wp-content/blogs.dir/sites/3/2016/11/23/UW-e1500720057243.png)
+
+I'm excited to learn more about developing software in a team environment during this virtual  
+internship.  Cheers!
+
+## Contact
+
+**LinkedIn**: [samliew211](https://www.linkedin.com/in/samliew211)

--- a/pages/vi/profiles/chiragawale.md
+++ b/pages/vi/profiles/chiragawale.md
@@ -1,0 +1,13 @@
+# 👨 Chirag Awale 
+## 🕒 Location/Time zone: Troy, Al, USA | CST 
+*🖥️ Operating System : mac OS Mojave 10.14.3*
+
+### Someone interested in learning and impacting lives, and striving towards self growth, bringing value to people around me. 
+
+## Social Media and links
+* [Linkedin](https://www.linkedin.com/in/chirag-awale)
+* [Github](https://github.com/ChiragAwale/)
+
+
+  
+

--- a/pages/vi/profiles/hiroTochigi.md
+++ b/pages/vi/profiles/hiroTochigi.md
@@ -1,0 +1,28 @@
+# Hiroyuki Terauchi
+
+Location | Time | OS
+--- | --- | ---
+Tulsa, OK | CST | Ubuntu 18.10
+
+## About Me
+I am studying Computer Science as a full-time student at [Northeastern State University](https://www.nsuok.edu/).
+
+I came from Japan🇯🇵 six years ago.
+
+I am so **excited** about this virtual internship.
+
+This is my home town; Tochigi city, Tochigi Prefecture, Japan.
+
+![Tochigi City](https://upload.wikimedia.org/wikipedia/commons/d/da/Tochigi_prefectural_road_No.11_on_Tochigi_city.jpg)
+
+## Learned Technology
+
+* HTML/CSS
+* JavaScript
+* C/C++
+* JAVA
+* Python
+* SQL
+
+
+

--- a/pages/vi/profiles/irisb1701.md
+++ b/pages/vi/profiles/irisb1701.md
@@ -1,0 +1,20 @@
+# Iris Beharaj
+![](https://render.fineartamerica.com/images/rendered/default/poster/10/8/break/images/artworkimages/medium/1/davis-square-sign-somerville-ma-mikes-toby-mcguire.jpg)
+
+🌎 Somerville, MA
+
+🕖 Eastern Standard Time
+
+💻 Windows 10 pro, 64-bit
+
+### About Me 
+
+>My name is Iris, I'm 25 years old, and I'm a first year graduate student at the Georgia Institute of Technology studying Computer Science through their online curriculum.
+
+
+### Fun Facts
+
+* I was born in Albania
+* I studied Economics for my undergrad and was bored my senior year so I took 5 CS courses
+* I love to paint
+  * At the moment my favorite things to paint are Game of Thrones characters

--- a/pages/vi/profiles/jeevast.md
+++ b/pages/vi/profiles/jeevast.md
@@ -1,0 +1,24 @@
+ # Jeeva Surulibommu Thudikarabommu
+
+| Location | Time zone| Operating system|
+|:---      | :-------:|             ---:|
+|New Jersey|    EST   | Ubuntu 18.04    |
+
+## About Myself
+
+Hello, I'm Jeeva,doing my Master's in computer science at NJIT and I'm passionate in what I do. I feel It's a great pleasure and
+a good opportunity to use my skills for social cause and I'm very much curious to work on this project as virtual Intern and move
+a step ahead.
+
+## skills acquired:
+* Java
+* HTML
+* CSS
+* C programming
+* Socket Programming
+* SQL
+* Javascript
+
+## Contact Details
+- GitHub: [github](https://github.com/jeevast)
+- Linkedin: [linked_in](https://www.linkedin.com/in/jeeva-st-49a33016b/)

--- a/pages/vi/profiles/lillyxxx.md
+++ b/pages/vi/profiles/lillyxxx.md
@@ -1,0 +1,18 @@
+# Lixiao Li
+
+|📍 Location|🕰️ Time Zone|💻 OS|
+|:------|:--------|:--|
+| Los Angeles, CA, US | [PDT/PST(GMT-7)](https://www.timeanddate.com/time/zone/usa/los-angeles) | **macOS** High Sierra v10.13.6 |
+
+## 🧠 About Me
+> Your imagination is your preview of life’s coming attractions.    *- Albert Einstein*
+
+ - ☑️ Always eager to learn new things
+ - ☑️ Strong pressure resistance and adaptability
+ - ☑️ Outgoing and
+ - ☑️ Love talking and sharing with others
+ -  🙅‍♀️ ~~Loquacious~~
+
+## 📝 Tech Skills
+- `Python, Java, C/C++, SQL`
+- Git, Shell scripting, OOD

--- a/pages/vi/profiles/samuelchen1213.md
+++ b/pages/vi/profiles/samuelchen1213.md
@@ -1,0 +1,20 @@
+## Information
+**Name:** Samuel Chen
+
+
+**Location/Timezone:** Canada (Eastern Daylight Time)
+
+
+**OS:** macOS Mohave 10.14.4
+
+
+
+## Description
+Hello everyone! My name is Samuel Chen and I attend the University of Waterloo for Computing and Financial Mangement. 
+I am extremely passionate of innovation, design, and entrepreneurship and believe working for OLE will be a great experience!
+
+You can find my linkedin page here if you want to connect with me: [Samuel's Linkedin](https://www.linkedin.com/in/samuelgychen/)
+
+Here is a picture of my school!
+![Waterloo University](https://i.cbc.ca/1.2955245.1423777526!/fileImage/httpImage/image.jpg_gen/derivatives/16x9_780/university-of-waterloo.jpg)
+![Alt Text](https://media.giphy.com/media/Cmr1OMJ2FN0B2/giphy.gif)

--- a/pages/vi/retiredinterns.md
+++ b/pages/vi/retiredinterns.md
@@ -2,7 +2,7 @@
 
 |**Username**|**Join Date**|**Until**|
 |------------|-------------|----|
-|[jeevast](profilenotfound.md)|2019-05-31|2019-09-31|
-|[samuelchen1213](profilenotfound.md)|2019-05-29|2019-08-29|
+|[jeevast](profiles/jeevast.md)|2019-05-31|2019-09-31|
+|[samuelchen1213](profiles/samuelchen1213.md)|2019-05-29|2019-08-29|
 
 To view current interns, please go to the [members page](team.md)

--- a/pages/vi/retiredinterns.md
+++ b/pages/vi/retiredinterns.md
@@ -2,5 +2,5 @@
 
 |**Username**|**Join Date**|**Until**|
 |------------|-------------|----|
-|[jeevast](profiles/jeevast.md)|2019-05-31|2019-09-31|
-|[samuelchen1213](profiles/samuelchen1213.md)|2019-05-29|2019-08-29|
+|[jeevast](profilenotfound.md)|2019-05-31|2019-09-31|
+|[samuelchen1213](profilenotfound.md)|2019-05-29|2019-08-29|

--- a/pages/vi/retiredinterns.md
+++ b/pages/vi/retiredinterns.md
@@ -4,3 +4,5 @@
 |------------|-------------|----|
 |[jeevast](profilenotfound.md)|2019-05-31|2019-09-31|
 |[samuelchen1213](profilenotfound.md)|2019-05-29|2019-08-29|
+
+To view current interns, please go to the [members page](team.md)

--- a/pages/vi/retiredinterns.md
+++ b/pages/vi/retiredinterns.md
@@ -1,0 +1,6 @@
+## Former Interns
+
+|**Username**|**Join Date**|**Until**|
+|------------|-------------|----|
+|[jeevast](profiles/jeevast.md)|2019-05-31|2019-09-31|
+|[samuelchen1213](profiles/samuelchen1213.md)|2019-05-29|2019-08-29|

--- a/pages/vi/team.md
+++ b/pages/vi/team.md
@@ -5,13 +5,13 @@
 |**Username**|**Join Date**|
 |------------|-------------|
 |**➤ Interns**||
-|[Liew211](profilenotfound.md)|2019-05-22|
-|[Kid243](profilenotfound.md)|2019-06-03|
+|[Liew211](profiles/Liew211.md)|2019-05-22|
+|[Kid243](profiles/Kid243.md)|2019-06-03|
 |[ArranHL](profiles/ArranHL.md)|2019-06-17|
-|[Chiragawale](profilenotfound.md)|2019-06-17|
-|[hiroTochigi](profilenotfound.md)|2019-06-29|
-|[Irisb1701](profilenotfound.md)|2019-07-03|
-|[Lillyxxx](profilenotfound.md)|2019-07-17|
+|[Chiragawale](profiles/chiragawale.md)|2019-06-17|
+|[hiroTochigi](profiles/hiroTochigi.md)|2019-06-29|
+|[Irisb1701](profiles/irisb1701.md)|2019-07-03|
+|[Lillyxxx](profiles/lillyxxx.md)|2019-07-17|
 |[CalebProvost](profiles/CalebProvost.md)|2019-09-04|
 |[AnPham](profiles/phamduchongan93.md)|2019-09-07|
 |[vmnet8](profiles/vmnet8.md)|2019-09-11|

--- a/pages/vi/team.md
+++ b/pages/vi/team.md
@@ -5,13 +5,13 @@
 |**Username**|**Join Date**|
 |------------|-------------|
 |**➤ Interns**||
-|[Liew211](profiles/Liew211.md)|2019-05-22|
-|[Kid243](profiles/Kid243.md)|2019-06-03|
+|[Liew211](profilenotfound.md)|2019-05-22|
+|[Kid243](profilenotfound.md)|2019-06-03|
 |[ArranHL](profiles/ArranHL.md)|2019-06-17|
-|[Chiragawale](profiles/chiragawale.md)|2019-06-17|
-|[hiroTochigi](profiles/hiroTochigi.md)|2019-06-29|
-|[Irisb1701](profiles/irisb1701.md)|2019-07-03|
-|[Lillyxxx](profiles/lillyxxx.md)|2019-07-17|
+|[Chiragawale](profilenotfound.md)|2019-06-17|
+|[hiroTochigi](profilenotfound.md)|2019-06-29|
+|[Irisb1701](profilenotfound.md)|2019-07-03|
+|[Lillyxxx](profilenotfound.md)|2019-07-17|
 |[CalebProvost](profiles/CalebProvost.md)|2019-09-04|
 |[AnPham](profiles/phamduchongan93.md)|2019-09-07|
 |[vmnet8](profiles/vmnet8.md)|2019-09-11|

--- a/pages/vi/team.md
+++ b/pages/vi/team.md
@@ -18,12 +18,4 @@
 |[Xavierh93](profiles/Xavierh93.md)|2019-09-19|
 |[pattanawadee88](profiles/pattanawadee88.md)|2019-09-20|
 
-## Former Interns
-
-|**Username**|**Join Date**|**Until**|
-|------------|-------------|----|
-|**➤ Interns**|||
-|[jeevast](profiles/jeevast.md)|2019-05-31|2019-09-31|
-|[samuelchen1213](profiles/samuelchen1213.md)|2019-05-29|2019-08-29|
-
 To view the list of former interns, go to [former members page](retiredinterns.md).


### PR DESCRIPTION
#### Changes Implemented:

- Added a `retiredmembers.md` file to display the retired interns.
- When clicking on a profile that does not exist, the user is redirected to a page that says: 
`"The user has not provided a profile"`

https://raw.githack.com/sriharivishnu/sriharivishnu.github.io/formermembers/#!pages/vi/team.md