### PR TITLE
Reboot pi after adding ssh key (fixes #260)

### DIFF
--- a/pages/vi/sshpi.md
+++ b/pages/vi/sshpi.md
@@ -53,7 +53,9 @@ To add your SSH key to your Raspberry Pi you first need to copy your public key.
 
 Now you can add the public key to run: `sudo treehouses sshkey add "your SSH key"` (copy-paste your SSH key in between the quotes) or just `sudo treehouse sshkey addgithubuser <yourgithubusername>`.
 
-In the future on ssh login it will ask you for your sshkey passphrase where as before used the default password for pi user "raspberry".
+Reboot your pi using `sudo reboot`.
+
+After rebooting your pi on ssh login it will ask you for your sshkey passphrase where as before you used the default password for pi user "raspberry".
 
 ### Log in by Root
 


### PR DESCRIPTION
<!-- This is a new pull request template for treehouses.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #260 

### Description
Provided more clarification to instruction of Step 2: Adding ssh keys section. Inform users that ssh password will become passphrase of ssh key only after they have rebooted their raspberry pi.

### Raw.Githack preview link
https://raw.githack.com/Nida8930/Nida8930.github.io/sshkey-branch/#!pages/vi/sshpi.md

### Checklist
[x]Check for issue number in pull request title.
[x]Are there any unneeded files in the pull request.
[x]Did they make make a branch for their patch?
[x]Does the pull request actually fix the issue?
[x]Check the request on raw.githack, does it display without any errors?
[x]Are there any merge conflicts?
[x]Make sure that people use their github accounts when making commits through git.
