### PR TITLE
Inserted additional commands for Linux docker download (fixes #292)

### DIFF
--- a/pages/vi/dockertutorial.md
+++ b/pages/vi/dockertutorial.md
@@ -68,7 +68,7 @@ Check your current Linux version with `hostnamectl` . Something like this will b
 You can also use `cat /etc/os-release` or `lsb_release -a`.  
 Any of these three commands will tell you the information you need.
 
-You will need to use `uname -r`.  You should see something like this `4.19.4-microsoft-standard` for a windows base linux system .
+You may need to use `uname -r`.  If using a windows based linux system.  You should see something like this `4.19.4-microsoft-standard`.
 
 For:
 

--- a/pages/vi/dockertutorial.md
+++ b/pages/vi/dockertutorial.md
@@ -70,7 +70,6 @@ Any of these three commands will tell you the information you need.
 
 You may need to use `uname -r`.  If using a windows based linux system.  You should see something like this `4.19.4-microsoft-standard`.
 
-For:
 
 #### For:
 - Disco 19.04

--- a/pages/vi/dockertutorial.md
+++ b/pages/vi/dockertutorial.md
@@ -52,7 +52,8 @@ No matter your distribution of choice, you’ll need a 64-bit installation and a
 Please find your distro at https://docs.docker.com/install/#server and follow the guide to install Docker CE.
 
 
-Check your current Linux version with `hostnamectl` . You should see something like:
+Check your current Linux version with `hostnamectl` . Something like this will be in the terminal output:
+
 ```  
     Static hostname: <your_host_name_here>
     Icon name: computer-laptop
@@ -63,8 +64,13 @@ Check your current Linux version with `hostnamectl` . You should see something l
     Kernel: Linux 4.15.0-70-generic
     Architecture: x86-64
 ```  
+
 You can also use `cat /etc/os-release` or `lsb_release -a`.  
-Any of these three commands will tell you the information you need to know prior to proceeding.  For a windows base linux system you should see the same output.
+Any of these three commands will tell you the information you need to know prior to proceeding.
+
+You will need to use `uname -r`.  You should see something like this `4.19.4-microsoft-standard` for a windows base linux system .
+
+For:
 
 #### For:
 - Disco 19.04

--- a/pages/vi/dockertutorial.md
+++ b/pages/vi/dockertutorial.md
@@ -52,8 +52,19 @@ No matter your distribution of choice, you’ll need a 64-bit installation and a
 Please find your distro at https://docs.docker.com/install/#server and follow the guide to install Docker CE.
 
 
-Check your current Linux version with `uname -r` . You should see something like `3.10.[alphanumeric string].x86_64` or `4.19.43-microsoft-standard` for a windows based Linux system.
-
+Check your current Linux version with `hostnamectl` . You should see something like:
+```  
+    Static hostname: <your_host_name_here>
+    Icon name: computer-laptop
+    Chassis: laptop
+    Machine ID: <your_machine_id_here>
+    Boot ID: <your_boot_id_here>
+    Operating System: Ubuntu 18.04.3 LTS 
+    Kernel: Linux 4.15.0-70-generic
+    Architecture: x86-64
+```  
+You can also use `cat /etc/os-release` or `lsb_release -a`.  
+Any of these three commands will tell you the information you need to know prior to proceeding.  For a windows base linux system you should see the same output.
 
 #### For:
 - Disco 19.04

--- a/pages/vi/dockertutorial.md
+++ b/pages/vi/dockertutorial.md
@@ -66,7 +66,7 @@ Check your current Linux version with `hostnamectl` . Something like this will b
 ```  
 
 You can also use `cat /etc/os-release` or `lsb_release -a`.  
-Any of these three commands will tell you the information you need to know prior to proceeding.
+Any of these three commands will tell you the information you need.
 
 You will need to use `uname -r`.  You should see something like this `4.19.4-microsoft-standard` for a windows base linux system .
 


### PR DESCRIPTION

Fixes #[292](https://github.com/treehouses/treehouses.github.io/issues/292#issue-533192191)   

### Description
I added three different commands that provide more information to the user while following the tutorial in step 4. System Tutorial, [Docker tutorial](https://treehouses.io/#!pages/vi/firststeps.md#Step_4_-_System_Tutorial).  The command `uname -r`, works for windows based linux systems to get the kernel information.  That is still part of the tutorial.  

### Raw.Githack preview link
[raw.githack](https://raw.githack.com/surferjreb/surferjreb.github.io/fix_command_linux_docker_download/#!./pages/vi/dockertutorial.md) link to dockertutorial.md.
