### PR TITLE
download: list of docker images (fixes #304)

### DIFF
--- a/pages/download.md
+++ b/pages/download.md
@@ -13,7 +13,7 @@ The main features of treehouses-powered Raspberry Pi image are
 
 * Bluetooth Remote Server, and many more 😀
 
-## Getting Other Images
+## Getting Other Images 
 
 If you need a specific version, you can download it [here](http://dev.ole.org/).
 

--- a/pages/download.md
+++ b/pages/download.md
@@ -3,11 +3,14 @@
 [DOWNLOAD LATEST IMAGE](http://dev.ole.org/latest.img.gz)
 
 The main features of treehouses-powered Raspberry Pi image are
+
 * Docker-ready
 * Educational applications that are only few commands away
   * [Planet](https://github.com/open-learning-exchange/planet/)
   * [Moodle](https://github.com/treehouses/moodole)
   * [Kolibri](https://github.com/treehouses/kolibri)
+  
+
 * Bluetooth Remote Server, and many more 😀
 
 ## Getting Other Images

--- a/pages/download.md
+++ b/pages/download.md
@@ -13,7 +13,7 @@ The main features of treehouses-powered Raspberry Pi image are
 
 * Bluetooth Remote Server, and many more 😀
 
-## Getting Other Images 
+## Getting Other Images
 
 If you need a specific version, you can download it [here](http://dev.ole.org/).
 


### PR DESCRIPTION


<!-- issue number this pull request resolves -->
Fixes #304 

### Description
Inserted _hard line space_ after intro sentence to fix appearance of mark down list.

### Raw.Githack preview link
[raw.githack link](https://raw.githack.com/surferjreb/surferjreb.github.io/download_appearance_fix/#!pages/download.md) to download.md.


