### PR TITLE
update first steps urls (fixes #352)

### DIFF
--- a/pages/vi/dockertutorial.md
+++ b/pages/vi/dockertutorial.md
@@ -111,3 +111,6 @@ Compose is a tool for defining and running multi-container Docker applications. 
 
 **NOTE**: At the end of this step, when you have completed all the sections and executed the `docker-compose --version` command go to the Gitter [chat](https://gitter.im/treehouses/Lobby) and post which version of docker you are running.
 " @/all I'm on step 4 - Docker Tutorial, I am running `docker version` and `docker compose version` "
+
+---
+#### Return to [First Steps](firststeps.md#Step_4_-_System_Tutorial)

--- a/pages/vi/find-pi.md
+++ b/pages/vi/find-pi.md
@@ -86,5 +86,5 @@ Your phone and your Raspberry Pi have to be on the same network, so connect your
 
 When you open the Fing app, touch the refresh button in the upper right-hand corner of the screen. After a few seconds you will get a list with all the devices connected to your network. Scroll down to the entry with the name "treehouses". You will see the IP address in the bottom left-hand corner, and the MAC address in the bottom right-hand corner of the entry.
 
-
-## Return to [First Steps](firststeps.md)
+---
+#### Return to [First Steps](firststeps.md#Step_1_-_Installing_and_finding_your_Raspberry_Pi)

--- a/pages/vi/github-issues.md
+++ b/pages/vi/github-issues.md
@@ -160,7 +160,5 @@ This is an exercise to help you familiarize with GitHub issues, committing, and 
 [Helpful links and videos](faq.md#Helpful_Links)
 [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 
-
-
-
-#### Return to [First Steps](firststeps.md)
+---
+#### Return to [First Steps](firststeps.md#Step_6_-_GitHub_Issues_Tutorial)

--- a/pages/vi/githubandmarkdown.md
+++ b/pages/vi/githubandmarkdown.md
@@ -149,4 +149,5 @@ After the pull request is merged, you'll be able to see your personal page at `t
 
 [Other helpful links and videos](faq.md#Helpful_Links)
 
-#### Return to [First Steps](firststeps.md)
+---
+#### Return to [First Steps](firststeps.md#Step_3_-_Markdown_and_Fork_Tutorial)

--- a/pages/vi/gitrepositories.md
+++ b/pages/vi/gitrepositories.md
@@ -219,15 +219,5 @@ If you would like to understand how syncing with the fork works, here is a usefu
 [Git help](https://git-scm.com/) - An encyclopedia of useful git workflows and terminology explanations.
 [Other helpful links and videos](faq.md#Helpful_Links)
 
-## You Earned It! (The Git Gooey Section)
-[List of Git GUI's](https://git-scm.com/downloads/guis)
-Recommended: [Git Extensions](https://sourceforge.net/projects/gitextensions/) (cross-platform)
-Have you ever wanted to Sync your Fork in a single click?
-Now you can with [UpRiver](https://upriver.github.io/)!
-
-
-## Next Section _(Step 6)_ **→**
-
-In the next section, you will learn the process for creating and resolving issues with GitHub.
-
-#### Return to [First Steps](firststeps.md#)
+---
+#### Return to [First Steps](firststeps.md#Step_5_-_Keeping_Fork_Updated)

--- a/pages/vi/gitrepositories.md
+++ b/pages/vi/gitrepositories.md
@@ -219,6 +219,13 @@ If you would like to understand how syncing with the fork works, here is a usefu
 [Git help](https://git-scm.com/) - An encyclopedia of useful git workflows and terminology explanations.
 [Other helpful links and videos](faq.md#Helpful_Links)
 
+## You Earned It! (The Git Gooey Section)
+[List of Git GUI's](https://git-scm.com/downloads/guis)
+Recommended: [Git Extensions](https://sourceforge.net/projects/gitextensions/) (cross-platform)
+Have you ever wanted to Sync your Fork in a single click?
+Now you can with [UpRiver](https://upriver.github.io/)!
+
+
 ## Next Section _(Step 6)_ **→**
 
 In the next section, you will learn the process for creating and resolving issues with GitHub.

--- a/pages/vi/nextcloud-tor.md
+++ b/pages/vi/nextcloud-tor.md
@@ -98,5 +98,5 @@ Once you reach this page, send a screenshot of the window (including the URL) in
 
 After you have created an admin account and logged in, you can play around with the settings, add users, install apps to augment your Nextcloud experience, and more.  As long as your Raspberry Pi is connected to internet, and the Docker container is running, you will be able to access Nextcloud through the same Tor address (if you forget it, you can always ssh into your Pi and run `treehouses tor`).
 
-
-[Return to First Steps](firststeps.md)
+---
+#### Return to [First Steps](firststeps.md#Step_7_-_other_Services_running_from_a_Raspberry_Pi)

--- a/pages/vi/pi-setup.md
+++ b/pages/vi/pi-setup.md
@@ -45,4 +45,5 @@ After getting your microSD cards and card reader/adapter, your first step will b
 1. Connect the power cable, and if your device has a power switch, turn it on.
     * A red "power" LED should turn on.
 
-## Next Section: [Using Treehouses Remote](treehouses-remote.md)
+---
+#### Next Section: [Using Treehouses Remote](treehouses-remote.md)

--- a/pages/vi/sshpi.md
+++ b/pages/vi/sshpi.md
@@ -99,7 +99,7 @@ Install [Tor](https://www.torproject.org/download/)
 
 To activate Tor, SSH into your Raspberry Pi with `root`, and run `treehouses tor add 22`, `treehouses tor add 80`, and `treehouses tor notice on`.  To view the Tor address of your Pi, run `treehouses tor`, then copy-paste this address into your Tor Browser, to make sure it works; you should see a configuration page for Planet Learning, one of our other services.
 
---------------------------------------------------------------
+---
 #### At the end of this section, post the code of your successful SSH terminal to the [Gitter chat](https://gitter.im/treehouses/Lobby)
 
 It may look like this:
@@ -120,9 +120,9 @@ Last login: Thu Aug 22 23:20:37 2019 from unknown.comcast.net
 root@treehouses:~#
 ```
 
---------------------------------------------------------------
+---
 
 You can find instructions on Code and Syntax Highlighting [here](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#code-and-syntax-highlighting)
 
-
-#### Return to [First Steps](firststeps.md#)
+---
+#### Return to [First Steps](firststeps.md#Step_2_-_Use_SSH_and_Tor_to_remotely_control_your_Raspberry_Pi)

--- a/pages/vi/treehouses-remote.md
+++ b/pages/vi/treehouses-remote.md
@@ -40,4 +40,6 @@ The app may ask for your device location, feel free to decline.
 **NOTE:** The time it takes to reboot is about 2-4 minutes.
 
 **NOTE:** You will need to unpair, re-pair, and restart your phone evey time you use a new image version.
-## Next Section: [Finding your Pi](find-pi.md)
+
+---
+#### Next Section: [Finding your Pi](find-pi.md)

--- a/pages/vi/vagranttutorial.md
+++ b/pages/vi/vagranttutorial.md
@@ -120,3 +120,6 @@ or not commonly used. To see all subcommands, run the command
 [Vagrant download](https://www.vagrantup.com/downloads.html)
 [Wikipedia page on Vagrant](https://en.wikipedia.org/wiki/Vagrant_%28software%29)
 [Other helpful links and videos](vi-faq.md#Helpful_Links)
+
+---
+#### Return to [First Steps](firststeps.md#Step_4_-_System_Tutorial)


### PR DESCRIPTION
### Description
Cleaned up the First Steps links to all h4 headers, hrs above them, all updated to same text,
and removed a faulty Next Section area that was out of place. Now each time you click "First Steps"
you go back to your place on the page of the step you were on. 

### Raw.Githack preview link
https://raw.githack.com/LordJashin32/lordjashin32.github.io/d5c7df83ceb698a0a0d7994b16d269bbfc02df6e/#!pages/vi/sshpi.md