### PR TITLE
update githubandmarkdown.md with dead url back tick (fixes #382)

### DIFF
--- a/pages/vi/githubandmarkdown.md
+++ b/pages/vi/githubandmarkdown.md
@@ -67,11 +67,11 @@ After you fork the repository, you will be on your repository: &lt;YourUserName&
 
 ![](images/fork1.png)
 
-**Note:** In case you have the **https://YourUserName.github.io** in use, please refer to the [FAQ](faq.md).
+**Note:** In case you have the **`https://YourUserName.github.io`** in use, please refer to the [FAQ](faq.md).
 
 ### Check to see if your github.io works
 
-After renaming your forked repository, go to  https://YourUserName.github.io and make sure it works.
+After renaming your forked repository, go to  `https://YourUserName.github.io` and make sure it works.
 
 Don't worry if you see a **404** page not found error. When you access the link, it will take a while for the page to load and run. Make sure in **Settings > GitHub Pages**, the **source** is set to **_master branch_**.
 


### PR DESCRIPTION
<!-- This is a new pull request template for treehouses.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
- [x] Fixes #382
- [x] Branch was made for this patch
- [x] PR displays on raw.githack without errors
- [x] No merge conflicts

### Description
Converted dead links to back tick text.

ex) [https://YourUserName.github.io](https://YourUserName.github.io) -> `https://YourUserName.github.io`

### Raw.Githack preview link
[https://raw.githack.com/garciaj92-OLE/garciaj92-OLE.github.io/remove-dead-link/#!pages/vi/githubandmarkdown.md](https://raw.githack.com/garciaj92-OLE/garciaj92-OLE.github.io/remove-dead-link/#!pages/vi/githubandmarkdown.md)
