### PR TITLE
templates: add spaces before headers (fixes #434)

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -8,14 +8,14 @@ You may preview your issue before submission.
 Please write N/A in the sections that aren't applicable to your particular issue.
 Thank you for contributing! -->
 
-### Problem
+ ### Problem
 Insert a short description of the problem.
 
-### Steps to reproduce the problem
+ ### Steps to reproduce the problem
 Write N/A if not applicable.
 
-### Screenshots
+ ### Screenshots
 Drag and drop images below. Write N/A if not applicable.
 
-### Proposed solution
+ ### Proposed solution
 Write N/A if not applicable.


### PR DESCRIPTION
<!-- This is a new pull request template for treehouses.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #434 

### Description
Added spaces before headers to prevent popups when previous text is removed.

### Raw.Githack preview link

https://raw.githack.com/ComputerOnFire/ComputerOnFire.github.io/template-fix/.github/ISSUE_TEMPLATE/issue_template.md
