### PR TITLE
update vagranttutorial.md (fixes #527)

### DIFF
--- a/pages/vi/vagranttutorial.md
+++ b/pages/vi/vagranttutorial.md
@@ -24,9 +24,9 @@ There are three command-line programs you could use to interact with Vagrant CLI
 **NOTE**: PowerShell and Command Prompt users will have to substitute forward slashes “/” with backslashes “\” throughout these introductory steps as it pertains to file paths.  
 Example: If you see an instruction saying `cd desktop/treehouses/cli` instead use `cd desktop\treehouses\cli`.
 
-#### macOS or Ubuntu - Terminal
+#### macOS or GNU\Linux -Terminal
 
-Normally we use Terminal to interact with Vagrant CLI.
+Normally we use a terminal emulator to interact with Vagrant CLI 
 
 ## Stay in the Right Directory
 

--- a/pages/vi/vagranttutorial.md
+++ b/pages/vi/vagranttutorial.md
@@ -26,7 +26,7 @@ Example: If you see an instruction saying `cd desktop/treehouses/cli` instead us
 
 #### macOS or GNU\Linux - Terminal
 
-Normally we use a terminal emulator to interact with Vagrant CLI 
+Normally we use a terminal emulator to interact with Vagrant CLI
 
 ## Stay in the Right Directory
 

--- a/pages/vi/vagranttutorial.md
+++ b/pages/vi/vagranttutorial.md
@@ -24,7 +24,7 @@ There are three command-line programs you could use to interact with Vagrant CLI
 **NOTE**: PowerShell and Command Prompt users will have to substitute forward slashes “/” with backslashes “\” throughout these introductory steps as it pertains to file paths.  
 Example: If you see an instruction saying `cd desktop/treehouses/cli` instead use `cd desktop\treehouses\cli`.
 
-#### macOS or GNU\Linux -Terminal
+#### macOS or GNU\Linux - Terminal
 
 Normally we use a terminal emulator to interact with Vagrant CLI 
 


### PR DESCRIPTION
Fixes #527 

### Description
Changed 'Ubuntu' to more generic 'GNU\Linux', changed 'Terminal' to more generic 'a terminal emulator'.

### Raw.Githack preview link
https://raw.githack.com/darthnoward/darthnoward.github.io/system/#!pages/vi/vagranttutorial.md
