### PR TITLE
update githubandmarkdown.md (fixes #697)

### DIFF
--- a/pages/vi/githubandmarkdown.md
+++ b/pages/vi/githubandmarkdown.md
@@ -139,8 +139,6 @@ After the pull request is merged, you'll be able to see your personal page at `t
 
 ## Useful Links
 
-[GitHub – Mastering Markdown](https://guides.github.com/features/mastering-markdown/) - The official GitHub Guide for Markdown syntax.
-
 [MDWiki – Quick Start](http://dynalon.github.io/mdwiki/#!quickstart.md) - The official MDwiki quick start guide on Markdown syntax.
 
 [GitHub - Writing and Formatting](https://help.github.com/categories/writing-on-github/) - A GitHub help page on how to format and write, along with working with saved replies.

--- a/pages/vi/githubandmarkdown.md
+++ b/pages/vi/githubandmarkdown.md
@@ -137,15 +137,5 @@ After the pull request is merged, you'll be able to see your personal page at `t
 
 **NOTE**: Try to add and experiment with as many markdown elements as you can and make your page attractive. A list of sample profile pages can be found [**here**](https://github.com/treehouses/treehouses.github.io/tree/master/pages/vi/profiles). Be creative.
 
-## Useful Links
-
-[MDWiki – Quick Start](http://dynalon.github.io/mdwiki/#!quickstart.md) - The official MDwiki quick start guide on Markdown syntax.
-
-[GitHub - Writing and Formatting](https://help.github.com/categories/writing-on-github/) - A GitHub help page on how to format and write, along with working with saved replies.
-
-[GitHub - How to fork a repo](https://help.github.com/articles/fork-a-repo/) - A more in-depth explanation about how and why we fork repositories.
-
-[Other helpful links and videos](faq.md#Helpful_Links)
-
 ---
 #### Return to [First Steps](firststeps.md#Step_3_-_Markdown_and_Fork_Tutorial)


### PR DESCRIPTION
<!-- This is a new pull request template for treehouses.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #697 

### Description
Removes duplicate "GitHub - Mastering Markdown" link under the header "Useful Links" from the GitHub and Markdown page.

### Raw.Githack preview link
https://raw.githack.com/mattscodeans/mattscodeans.github.io/remove-duplicate-link/#!pages/vi/githubandmarkdown.md
