### PR TITLE
Add Docker commands to tutorial (fixes #792)

### DIFF
--- a/pages/vi/dockertutorial.md
+++ b/pages/vi/dockertutorial.md
@@ -106,8 +106,6 @@ Please read about [Docker concepts](https://docs.docker.com/get-started/#docker-
 
 A few common Docker CLI commands you might need for working with `treehouses` are:
 
-- `docker start <container-id>` – start one or multiple stopped containers
-- `docker stop <container-id>` - stop one or multiple running containers
 - `docker ps` – show running containers
 - `docker ps -a` - show all containers
 - `docker logs <container-id> -f` - follow the log output of a container

--- a/pages/vi/dockertutorial.md
+++ b/pages/vi/dockertutorial.md
@@ -106,6 +106,8 @@ Please read about [Docker concepts](https://docs.docker.com/get-started/#docker-
 
 A few common Docker CLI commands you might need for working with `treehouses` are:
 
+- `docker start <container-id>` – start one or multiple stopped containers
+- `docker stop <container-id>` - stop one or multiple running containers
 - `docker ps` – show running containers
 - `docker ps -a` - show all containers
 - `docker logs <container-id> -f` - follow the log output of a container

--- a/pages/vi/orientation.md
+++ b/pages/vi/orientation.md
@@ -47,7 +47,7 @@ To stay up to date with the projects you are contributing to, make sure you "sta
 
 #### [Docker](https://hub.docker.com/r/treehouses/)
 * Docker is a powerful and widely-used software option for creating, deploying, and running applications in containers
-  * Used by OLE for educational applications such as `planet`
+  * Used by OLE for educational applications such as [`planet`](https://www.ole.org/our-platform/)
 
 ## A Few Things to Know...
 

--- a/pages/vi/orientation.md
+++ b/pages/vi/orientation.md
@@ -47,7 +47,7 @@ To stay up to date with the projects you are contributing to, make sure you "sta
 
 #### [Docker](https://hub.docker.com/r/treehouses/)
 * Docker is a powerful and widely-used software option for creating, deploying, and running applications in containers
-  * Used by OLE for educational applications such as [`planet`](https://www.ole.org/our-platform/)
+  * Used by OLE for educational applications such as `planet`
 
 ## A Few Things to Know...
 


### PR DESCRIPTION
<!-- This is a new pull request template for treehouses.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #792 

### Description
Added the `docker start` and `docker stop` commands to the list of common commands in the Docker tutorial (changes are **bolded**):

> A few common Docker CLI commands you might need for working with `treehouses` are:
> 
> - **`docker start <container-id>` – start one or multiple stopped containers**
> - **`docker stop <container-id>` - stop one or multiple running containers**
> - `docker ps` – show running containers
> - `docker ps -a` - show all containers
> - `docker logs <container-id> -f` - follow the log output of a container
> - `docker images` – list images

### Raw.Githack preview link
https://raw.githack.com/JLKwong/JLKwong.github.io/792-Add-Docker-Commands/#!pages/vi/dockertutorial.md
