### PR TITLE
Add root password in Step 7 (fixes #760)

### DIFF
--- a/pages/vi/nextcloud-tor.md
+++ b/pages/vi/nextcloud-tor.md
@@ -61,7 +61,10 @@ Install [Tor](https://www.torproject.org/download/)
 
 Plug the microSD into your Raspberry Pi, and power it on.  The red LED should turn on, indicating that the Raspberry Pi is connected to power.  Once the green LED next to it on your Raspberry Pi stabilizes into a solid green, you should see "treehouses" appear in available Wifi networks.  Connect to it, and make sure that you have an internet connection by opening up another web page.  
 
-Find the Raspberry Pi's IP address in your network settings (it will probably be `192.168.2.1`).  Open up your terminal or command prompt, and run `ssh root@[IP address]` to enter the root of your Pi or, to log into the Pi user use `ssh pi@[local IP address]` and to log into root, you can run `sudo -s`.
+Find the Raspberry Pi's IP address in your network settings (it will probably be 192.168.2.1). Open up your terminal or command prompt, and use one of the following ways to enter the root of your Pi:
+- run ssh root@[IP address] to enter the root of your Pi using the password (root password).
+- First log into the Pi user by using ssh pi@[local IP address] using the (default) password "raspberry", then log into the root by running sudo -s.
+
 Run
 ```
 docker run -d -p 8080:80 --name nextcloud --restart=unless-stopped nextcloud

--- a/pages/vi/nextcloud-tor.md
+++ b/pages/vi/nextcloud-tor.md
@@ -62,8 +62,8 @@ Install [Tor](https://www.torproject.org/download/)
 Plug the microSD into your Raspberry Pi, and power it on.  The red LED should turn on, indicating that the Raspberry Pi is connected to power.  Once the green LED next to it on your Raspberry Pi stabilizes into a solid green, you should see "treehouses" appear in available Wifi networks.  Connect to it, and make sure that you have an internet connection by opening up another web page.  
 
 Find the Raspberry Pi's IP address in your network settings (it will probably be 192.168.2.1). Open up your terminal or command prompt, and use one of the following ways to enter the root of your Pi:
-- run ssh root@[IP address] to enter the root of your Pi using the password (root password).
-- First log into the Pi user by using ssh pi@[local IP address] using the (default) password "raspberry", then log into the root by running sudo -s.
+* Run ssh root@[IP address] to enter the root of your Pi using the password (root password).
+* First log into the Pi user by using ssh pi@[local IP address] using the (default) password "raspberry", then log into the root by running sudo -s.
 
 Run
 ```


### PR DESCRIPTION
<!-- This is a new pull request template for treehouses.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #760

### Description
Added text specifying what the root password is in this step and that the default password is "raspberry". Then, I revised the awkward syntax to be easier to follow:

> Find the Raspberry Pi's IP address in your network settings (it will probably be 192.168.2.1). Open up your terminal or command prompt, and use one of the following ways to enter the root of your Pi:
> * run ssh root@[IP address] to enter the root of your Pi using the password (root password).
> * First log into the Pi user by using ssh pi@[local IP address] using the (default) password "raspberry", then log into the root by running sudo -s.

### Raw.Githack preview link
https://raw.githack.com/JLKwong/JLKwong.github.io/760-Add-Root-Password/#!pages/vi/nextcloud-tor.md